### PR TITLE
Allow 'wagtailadmin_sprite' url to bypass 2FA

### DIFF
--- a/src/wagtail_2fa/middleware.py
+++ b/src/wagtail_2fa/middleware.py
@@ -14,6 +14,10 @@ class VerifyUserMiddleware(_OTPMiddleware):
         "wagtailadmin_login",
         "wagtailadmin_logout",
         "wagtailadmin_javascript_catalog",
+
+        # Needed because Wagtail will try to load HTML from this url and inserts it in the DOM.
+        # We don't want it to inject the HTML from the 2FA required page.
+        "wagtailadmin_sprite",
     ]
 
     # These URLs do not require verification if the user has no devices


### PR DESCRIPTION
Wagtail attempts to load SVG sprites from this url and injects them into the browsers DOM. When this url is guarded by 2FA, the HTML of the 2FA verification page is injected into the DOM instead. This results in a duplicate form on the page.