### PR TITLE
Wagtail 6.1

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,8 +1,8 @@
 Unreleased
 ==========
- - Add support for Wagtail 5.2 and 6.0
+ - Add support for Wagtail 5.2 and 6.x
  - Drop support for Wagtail < 5.2
- - Update `otp_form` to be compatible with Wagtail 5.2 and 6.0
+ - Update `otp_form` to be compatible with Wagtail 5.2 and 6.x
  - Add support for Django 5.0
 
 

--- a/src/wagtail_2fa/templates/wagtail_2fa/device_list.html
+++ b/src/wagtail_2fa/templates/wagtail_2fa/device_list.html
@@ -46,7 +46,10 @@
 
         {# Users can only add devices to their own account #}
         {% if user_id == request.user.id %}
-            <a href="{% url 'wagtail_2fa_device_new' %}" class="button bicolor icon icon-plus">{% trans 'New device' %}</a>
+            <a href="{% url 'wagtail_2fa_device_new' %}" class="button bicolor button--icon">
+                <span class="icon-wrapper"><svg class="icon icon-plus icon" aria-hidden="true"><use href="#icon-plus"></use></svg></span>
+                {% trans 'New device' %}
+            </a>
         {% endif %}
     </div>
 {% endblock %}

--- a/src/wagtail_2fa/wagtail_hooks.py
+++ b/src/wagtail_2fa/wagtail_hooks.py
@@ -3,9 +3,10 @@ from django.contrib.auth.models import Permission
 from django.urls import path, reverse
 from django.utils.translation import gettext_lazy as _
 
-from wagtail import hooks
+from wagtail import hooks, VERSION as WAGTAIL_VERSION
 from wagtail.admin.menu import MenuItem
 from wagtail.users.widgets import UserListingButton
+
 
 from wagtail_2fa import views
 
@@ -68,14 +69,24 @@ def register(request):
     }
 
 
-@hooks.register("register_user_listing_buttons")
-def register_user_listing_buttons(context, user):
-    yield UserListingButton(
-        _("Manage 2FA"),
-        reverse("wagtail_2fa_device_list", kwargs={"user_id": user.id}),
-        attrs={"title": _("Edit this user")},
-        priority=100,
-    )
+if WAGTAIL_VERSION >= (6, 1):
+    @hooks.register("register_user_listing_buttons")
+    def register_user_listing_buttons(user, request_user):
+        yield UserListingButton(
+            _("Manage 2FA"),
+            reverse("wagtail_2fa_device_list", kwargs={"user_id": user.id}),
+            attrs={"title": _("Edit this user")},
+            priority=100,
+        )
+else:
+    @hooks.register("register_user_listing_buttons")
+    def register_user_listing_buttons(context, user):
+        yield UserListingButton(
+            _("Manage 2FA"),
+            reverse("wagtail_2fa_device_list", kwargs={"user_id": user.id}),
+            attrs={"title": _("Edit this user")},
+            priority=100,
+        )
 
 
 @hooks.register("register_permissions")

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,8 @@
 [tox]
 envlist =
     python{3.8,3.9,3.10}-django3.2-wagtail5.2
-    python{3.8,3.9,3.10,3.11}-django4.2-wagtail{5.2,6.0}
-    python{3.11,3.12}-django5.0-wagtail{5.2,6.0}
+    python{3.8,3.9,3.10,3.11}-django4.2-wagtail{5.2,6.0,6.1}
+    python{3.11,3.12}-django5.0-wagtail{5.2,6.0,6.1}
 
 [gh-actions]
 python =
@@ -28,6 +28,7 @@ deps =
     django5.0: Django>=5.0,<5.1
     wagtail5.2: wagtail>=5.2,<6.0
     wagtail6.0: wagtail>=6.0,<6.1
+    wagtail6.1: wagtail>=6.1,<6.2
 
 extras = test
 


### PR DESCRIPTION
# Wagtail 6.1 upgrade check list

## Code reviewing a consideration.
Use the tick box to indicate a consideration has been code reviewed as OK

### What’s new
  - [x] [Universal listings continued](https://docs.wagtail.org/en/latest/releases/6.1.html#universal-listings-continued)
  - [x] [Information-dense admin interface](https://docs.wagtail.org/en/latest/releases/6.1.html#information-dense-admin-interface)
  - [x] [Custom per-page-type listings](https://docs.wagtail.org/en/latest/releases/6.1.html#custom-per-page-type-listings)
  - [x] [Keyboard shortcuts overview](https://docs.wagtail.org/en/latest/releases/6.1.html#keyboard-shortcuts-overview)
  - [x] [Better guidance for password-protected content](https://docs.wagtail.org/en/latest/releases/6.1.html#better-guidance-for-password-protected-content)
  - [x] [Favicon images generation](https://docs.wagtail.org/en/latest/releases/6.1.html#favicon-images-generation)
  - [x] [Cve-2024-32882: permission check bypass when editing a model with per-field restrictions through wagtail.contrib.settings or modelviewset](https://docs.wagtail.org/en/latest/releases/6.1.html#cve-2024-32882-permission-check-bypass-when-editing-a-model-with-per-field-restrictions-through-wagtail-contrib-settings-or-modelviewset)
  - [x] [Other features](https://docs.wagtail.org/en/latest/releases/6.1.html#other-features)
  - [x] [Bug fixes](https://docs.wagtail.org/en/latest/releases/6.1.html#bug-fixes)
  - [x] [Documentation](https://docs.wagtail.org/en/latest/releases/6.1.html#documentation)
  - [x] [Maintenance](https://docs.wagtail.org/en/latest/releases/6.1.html#maintenance)
### Changes affecting wagtail customizations
  - [x] [Changes to submissionslistview class](https://docs.wagtail.org/en/latest/releases/6.1.html#changes-to-submissionslistview-class)
  - [x] [Register_user_listing_buttons hook signature changed](https://docs.wagtail.org/en/latest/releases/6.1.html#register-user-listing-buttons-hook-signature-changed)
  - [x] [Password_required_template has changed to wagtail_password_required_template](https://docs.wagtail.org/en/latest/releases/6.1.html#password-required-template-has-changed-to-wagtail-password-required-template)
  - [x] [Document_password_required_template has changed to wagtaildocs_password_required_template](https://docs.wagtail.org/en/latest/releases/6.1.html#document-password-required-template-has-changed-to-wagtaildocs-password-required-template)
### Changes to undocumented internals
  - [x] [Deprecation of user_listing_buttons template tag](https://docs.wagtail.org/en/latest/releases/6.1.html#deprecation-of-user-listing-buttons-template-tag)
  - [x] [Deprecation of wagtailusers_groups:users url pattern](https://docs.wagtail.org/en/latest/releases/6.1.html#deprecation-of-wagtailusers-groups-users-url-pattern)
  - [x] [Deprecation of window.chooserurls within draftail choosers](https://docs.wagtail.org/en/latest/releases/6.1.html#deprecation-of-window-chooserurls-within-draftail-choosers)
  - [x] [Deprecation of window.initblockwidget to initialize a streamfield block](https://docs.wagtail.org/en/latest/releases/6.1.html#deprecation-of-window-initblockwidget-to-initialize-a-streamfield-block)
  - [x] [Old](https://docs.wagtail.org/en/latest/releases/6.1.html#id1)
  - [x] [New](https://docs.wagtail.org/en/latest/releases/6.1.html#id2)
  - [x] [Removal of jquery from base client-side widget and boundwidget classes](https://docs.wagtail.org/en/latest/releases/6.1.html#removal-of-jquery-from-base-client-side-widget-and-boundwidget-classes)
  - [x] [Window.urlify deprecated](https://docs.wagtail.org/en/latest/releases/6.1.html#window-urlify-deprecated)
  - [x] [Window.xregexp polyfill removed](https://docs.wagtail.org/en/latest/releases/6.1.html#window-xregexp-polyfill-removed)