### PR TITLE
Support/wagtail 64 upgrade

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,5 +1,7 @@
 Unreleased
 ==========
+ - Add tox testing for Wagtail 6.4
+ - Add our own fork documentation to the README
  - Add testing for Wagtail 6.2
  - Drop testing for Django 3.2
  - Add support for Wagtail 5.2 and 6.x

--- a/sandbox/requirements.txt
+++ b/sandbox/requirements.txt
@@ -1,4 +1,4 @@
-Django>=4.2,<5.2
+Django>=4.2
 wagtail>=5.2
 django-debug-toolbar==4.4.6
 -e .[docs,test]

--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ setup(
         "docs": docs_require,
         "test": tests_require,
     },
-    python_requires=">=3.8",
+    python_requires=">=3.9",
     use_scm_version=True,
     entry_points={},
     package_dir={"": "src"},

--- a/src/wagtail_2fa/views.py
+++ b/src/wagtail_2fa/views.py
@@ -1,13 +1,9 @@
 import qrcode
 import qrcode.image.svg
-from django import VERSION as DJANGO_VERSION
 from django.conf import settings
 from django.contrib.auth import REDIRECT_FIELD_NAME
 
-if DJANGO_VERSION >= (4, 1):
-    from django.contrib.auth.views import RedirectURLMixin
-else:
-    from django.contrib.auth.views import SuccessURLAllowedHostsMixin as RedirectURLMixin
+from django.contrib.auth.views import RedirectURLMixin
 
 from wagtail import VERSION as WAGTAIL_VERSION
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,8 @@
 [tox]
 envlist =
-    python{3.9,3.10,3.11,3.12}-django4.2-wagtail{5.2,6.2,6.3}
-    python{3.10,3.11,3.12}-django5.0-wagtail{5.2,6.2,6.3}
-    python{3.10,3.11,3.12,3.13}-django5.1-wagtail6.3
+    python{3.9,3.10,3.11,3.12}-django4.2-wagtail{5.2,6.2,6.3,6.4}
+    python{3.10,3.11,3.12}-django5.0-wagtail{5.2,6.2,6.3,6.4}
+    python{3.10,3.11,3.12,3.13}-django5.1-wagtail{6.3,6.4}
 
 [gh-actions]
 python =
@@ -29,6 +29,7 @@ deps =
     wagtail5.2: wagtail>=5.2,<6.0
     wagtail6.2: wagtail>=6.2,<6.3
     wagtail6.3: wagtail>=6.3,<6.4
+    wagtail6.4: wagtail>=6.4,<6.5
 
 extras = test
 


### PR DESCRIPTION
This pull request includes several updates to add support for new versions, update dependencies, and clean up code. 

### New Version Support and Testing:

* Added tox testing for Wagtail 6.4 and updated the `tox.ini` file to include Wagtail 6.4 in the test environments.
* Added our own fork documentation to the README.

### Dependency Updates:

* Updated `sandbox/requirements.txt` to remove the upper version limit for Django, allowing for versions higher than 5.2.

### Code Cleanup:

* Removed version check for Django in `src/wagtail_2fa/views.py` and directly imported `RedirectURLMixin`.

### Fork Repo Branch Changes

* Not included here but please review the extra content at the beginning of the README doc